### PR TITLE
move SVA from mature

### DIFF
--- a/default.htm
+++ b/default.htm
@@ -141,7 +141,8 @@
 	<li><b>Joint Use Survey Dashboard</b> - <a href="http://links.esri.com/utilities/electric/TryItLive/JointUseSurveyDashboard">Try It Live</a></li>	
     <li><b>Pole Reports</b> - <a href="http://links.esri.com/utilities/electric/TryItLive/PoleReports">Try It Live</a></li>
     <li><b>Public Outage Map</b> - <a href="http://links.esri.com/utilities/electric/TryItLive/PublicOutageViewer">Try It Live</a></li>
-    <li><b>Report Streetlight Problem</b> - <a href="http://links.esri.com/utilities/electric/TryItLive/ReportStreetlightProblem">Try It Live</a></li>	
+    <li><b>Report Streetlight Problem</b> - <a href="http://links.esri.com/utilities/electric/TryItLive/ReportStreetlightProblem">Try It Live</a></li>
+    <li><b>Storm Vulnerability Assessment</b> - <a href="http://links.esri.com/utilities/electric/TryItLive/StormVulnerabilityAssessment">Try It Live</a></li>	
     <li><b>System Improvement Map</b> - <a href="http://links.esri.com/utilities/electric/TryItLive/SystemImprovement">Try It Live</a></li>
 </ul>
     <h2 style ="font-family:arial;color:midnightblue;font">ArcGIS for Water</h2>
@@ -223,8 +224,7 @@
     <li><b>Land Use Public Comment</b> - <a href="http://tryitlive.arcgis.com/LUPublicComment">Try It Live</a></li>
     <li><b>Parks and Recreation Finder (mature support- Local) </b> - <a href="http://tryitlive.arcgis.com/ParksFinder">Try It Live</a></li>
     <li><b>Parks Locator (mature support - State)</b> - <a href="http://tryitlive.arcgis.com/parkslocator">Try It Live</a></li>
-    <li><b>Public Information Center (mature support)</b> - <a href="http://tryitlive.arcgis.com/PublicInfoCenter">Try It Live</a></li>
-    <li><b>Storm Vulnerability Assessment (mature support)</b> - <a href="http://links.esri.com/utilities/electric/TryItLive/StormVulnerabilityAssessment">Try It Live</a></li>
+    <li><b>Public Information Center (mature support)</b> - <a href="http://tryitlive.arcgis.com/PublicInfoCenter">Try It Live</a></li>    
     <li><b>Water Access Locator (mature support)</b> - <a href="http://tryitlive.arcgis.com/wateraccess">Try It Live</a></li>
     <li><b>Wildlife Management Area Locator (mature support)</b> - <a href="http://tryitlive.arcgis.com/wma">Try It Live</a></li>
 </ul>


### PR DESCRIPTION
Storm Vulnerability Assessment is not being added to mature support at this time, so move back to Electric group